### PR TITLE
Enable hover-triggered name animation

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,12 +82,14 @@ import Card from '../components/Card.astro';
     <script>
       const letters = document.querySelectorAll('.name-heading .letter');
       letters.forEach((letter) => {
-        letter.addEventListener('pointerdown', () => {
-          const el = letter as HTMLElement;
+        const el = letter as HTMLElement;
+        const jump = () => {
           el.classList.remove('jump');
           void el.offsetWidth;
           el.classList.add('jump');
-        });
+        };
+        letter.addEventListener('pointerdown', jump);
+        letter.addEventListener('pointerenter', jump);
       });
     </script>
   </Card>


### PR DESCRIPTION
## Summary
- let the letters in the name jump on hover as well as click in `index.astro`

## Testing
- `yarn build` *(fails: `astro` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478c2d42f08332809d670fbe0849ba