### PR TITLE
Build robots.txt sitemap URL from request origin

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,13 +1,13 @@
 import type { APIRoute } from 'astro';
 
-const robotsTxt = `
+export const GET: APIRoute = ({ request }) => {
+  const siteUrl = import.meta.env.SITE || new URL(request.url).origin;
+  const robotsTxt = `
 User-agent: *
 Allow: /
-
-Sitemap: ${new URL('sitemap-index.xml', import.meta.env.SITE).href}
+Sitemap: ${new URL('sitemap-index.xml', siteUrl).href}
 `.trim();
 
-export const GET: APIRoute = () => {
   return new Response(robotsTxt, {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',


### PR DESCRIPTION
## Summary
- build the robots.txt response at request time so the sitemap URL uses import.meta.env.SITE when available
- fall back to the incoming request origin to ensure a valid sitemap link in all environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f80ce4d0d08332bebb063b61fc68ac